### PR TITLE
Fix variable name

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -215,7 +215,7 @@ tablet_offset_x      = ${screen_1W}
 tablet_offset_y      = 0
 
 xrandr_output1 = --output HDMI-0 --mode ${screen_1W}x${screen_1H} --pos 0x0 --rotate normal
-xrandr_output3 = --output VGA-0 --mode ${screen_3W}x${screen_3H} --pos ${screen_1W}x0 --rotate normal
+xrandr_output2 = --output VGA-0 --mode ${screen_3W}x${screen_3H} --pos ${screen_1W}x0 --rotate normal
 xrandr_args = ${xrandr_output1} ${xrandr_output2}
 
 


### PR DESCRIPTION
In the monitor_2 setup a var was named xrandr_output3. Probably copied from another setup