### PR TITLE
Replace ast.literal_eval with eval

### DIFF
--- a/huion-tablet-driver.py
+++ b/huion-tablet-driver.py
@@ -406,7 +406,7 @@ def read_config():
 
     current_monitor_setup = config.get('config',
         'current_monitor_setup').split("#",1)[0].strip('[]').strip()
-    main.settings['total_screen_width'] = ast.literal_eval(config.get(current_monitor_setup,
+    main.settings['total_screen_width'] = eval(config.get(current_monitor_setup,
         'total_screen_width').split("#",1)[0].strip())
     main.settings['total_screen_height'] = ast.literal_eval(config.get(current_monitor_setup,
         'total_screen_height').split("#",1)[0].strip())


### PR DESCRIPTION
The script errored on me here. I believe `ast.literal_eval` breaks on the + operator, which `eval` does not. There are more ast.literal_eval calls, they didn't break on me, but I have not used all monitor setups, so a thorough check on all of them would be in order. I am not a Python dev so please review this change carefully.